### PR TITLE
Add CMake build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 tmp/
 share/
 cfg.sh
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Need 3.1 for target_compile_features
+cmake_minimum_required(VERSION 3.1)
+project(cron VERSION 1.0)
+
+# TODO: Choose standard library from those available based on version
+add_compile_options(-stdlib=libc++)
+
+add_subdirectory(c++)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Need 3.1 for target_compile_features
 cmake_minimum_required(VERSION 3.1)
 project(cron VERSION 1.0)
+enable_testing()
+
+add_custom_target(check
+  ${CMAKE_COMMAND} -E env CTEST_OUTPUT_ON_FAILURE=1 GTEST_COLOR=1
+  ${CMAKE_CTEST_COMMAND} -C $<CONFIG> --verbose
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # TODO: Choose standard library from those available based on version
 add_compile_options(-stdlib=libc++)

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -1,0 +1,9 @@
+file(GLOB SOURCES "src/*.cc")
+add_library(cron ${SOURCES})
+set_property(TARGET cron PROPERTY CXX_STANDARD 11)
+target_compile_features(cron
+  PUBLIC cxx_relaxed_constexpr
+  )
+target_include_directories(cron
+  PUBLIC include
+  )

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -1,9 +1,35 @@
 file(GLOB SOURCES "src/*.cc")
 add_library(cron ${SOURCES})
 set_property(TARGET cron PROPERTY CXX_STANDARD 11)
-target_compile_features(cron
-  PUBLIC cxx_relaxed_constexpr
-  )
-target_include_directories(cron
-  PUBLIC include
-  )
+target_compile_features(cron PUBLIC cxx_relaxed_constexpr)
+target_include_directories(cron PUBLIC include)
+
+install(TARGETS cron DESTINATION lib)
+install(DIRECTORY include/cron DESTINATION include)
+
+# Download and unpack googletest at configure time
+set(GTEST_DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/googletest-download)
+configure_file(CMakeLists.txt.googletest
+  ${GTEST_DOWNLOAD_DIR}/CMakeLists.txt)
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  WORKING_DIRECTORY ${GTEST_DOWNLOAD_DIR})
+execute_process(
+  COMMAND ${CMAKE_COMMAND} --build .
+  WORKING_DIRECTORY ${GTEST_DOWNLOAD_DIR})
+
+# Prevent GoogleTest from overriding our compiler/linker options
+# when building with Visual Studio
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+# Add googletest directly to our build. This adds
+# the following targets: gtest, gtest_main, gmock
+# and gmock_main
+add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
+                 ${CMAKE_BINARY_DIR}/googletest-build
+                 EXCLUDE_FROM_ALL)
+
+file(GLOB TESTS "test/*.cc")
+add_executable(cron-gtest ${TESTS})
+target_link_libraries(cron-gtest cron gtest_main)
+add_test(all-tests cron-gtest)

--- a/c++/CMakeLists.txt.googletest
+++ b/c++/CMakeLists.txt.googletest
@@ -1,0 +1,16 @@
+# Thanks to http://crascit.com/2015/07/25/cmake-gtest/
+cmake_minimum_required(VERSION 3.1)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)


### PR DESCRIPTION
Here's a good start at using CMake, I think. What it can do now:

- Download and build Google Test (you can remove gtest from the repo when you're ready)
- Build cron C++ library
- Build and run cron C++ tests
- Install cron library and headers

Plus, since it's CMake, you get out-of-source builds and project generation for a number of IDEs for free.

If you describe to me the idea behind the Python (any build step? does it depend on the C++ library?) and how it's tested (nosetests? tox?), I can start taking a crack at adding it to the CMake build.