### PR TITLE
Fix NumPy support when building via setup.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ $(CXX_TST_OKS): export ZONEINFO = $(ABSTOP)/$(ZONEINFO_DIR)
 # Python building extension code
 
 # Enable NumPy features.
-PY_NP	    	= no
+PY_NP	       ?= no
 
 # Sources
 PY_INCDIRS      = $(PY_PKGDIR)/ext

--- a/setup.py
+++ b/setup.py
@@ -27,12 +27,16 @@ if sys.platform == "darwin":
 
 #-------------------------------------------------------------------------------
 
+try:
+    import numpy
+    _has_numpy = True
+except ImportError:
+    _has_numpy = False
+
 def np_get_include():
-    try:
-        import numpy
+    if _has_numpy:
         return [numpy.get_include()]
-    except ImportError:
-        return []
+    return []
 
 
 # Convince setuptools to call our C++ build.
@@ -89,13 +93,15 @@ setup(
                 "-std=c++17",
                 "-fdiagnostics-color=always",
                 "-Wno-dangling-else",
+                *([ "-DORA_NP" ] if _has_numpy else []),
             ],
             include_dirs      =[
                 "cxx/include",
                 "python/ora/ext",
                 *np_get_include(),
             ],
-            sources           =glob("python/ora/ext/*.cc"),
+            sources           =glob("python/ora/ext/*.cc")
+                              + (glob("python/ora/ext/np/*.cc") if _has_numpy else []),
             library_dirs      =["cxx/src", ],
             libraries         =["ora", ],
             depends           =[


### PR DESCRIPTION
In `v0.8.x`, NumPy was a hard dependency, `setup.py` did `import numpy as np` at the top level, and all NumPy C++ code was compiled unconditionally inline in `ext/*.cc`.

In commits fa43675 and e6e9fd5, NumPy was made an optional dependency:
- NumPy C++ code was moved into a separate `ext/np/` subdirectory
- `#ifdef ORA_NP` guards were added around NumPy code in the main source files
- A `PY_NP` Makefile variable was introduced to conditionally include `np/*.cc` sources, `-DORA_NP`, and NumPy docstrings
- `setup.py` was updated to detect NumPy and pass `PY_NP=yes/no` to make cxx docstrings
- NumPy was moved from `install_requires` to `extras_require`

The Makefile side was done correctly, but two issues were left in the build:
- `Makefile`: `PY_NP = no` (unconditional assignment) overrides the `PY_NP=yes` environment variable from `setup.py`, preventing NumPy docstring generation and causing fatal error: `np/np_date.docstrings.hh.inc: No such file or directory.`
- `setup.py`: The Extension definition was not updated to match — it still only includes `glob("python/ora/ext/*.cc")` and never passes `-DORA_NP` to the compiler. So even if docstrings are generated, the NumPy sources are never compiled and `ora.ext` has no np attribute.


### Fix
- Makefile: `PY_NP = no` → `PY_NP ?= no`, so the environment variable from `setup.py` takes effect.
- `setup.py`: Conditionally add `glob("python/ora/ext/np/*.cc")` to sources and `-DORA_NP` to compile flags when NumPy is
  importable at build time.

### Verification
**Before the fix**:
```
> python -c "import ora; print(ora.__version__); import ora.np; print(ora.np)"
0.10.3
Traceback (most recent call last):
  File "/home/lrighi/ora/python/ora/np/__init__.py", line 21, in <module>
    ext.np
AttributeError: module 'ora.ext' has no attribute 'np'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/lrighi/ora/python/ora/np/__init__.py", line 24, in <module>
    raise ImportError("Ora not build with NumPy support")
ImportError: Ora not build with NumPy support
```
**After the fix**:
```
> python -c "import ora; print(ora.__version__); import ora.np; print(ora.np)"
0.10.3
<module 'ora.np' from '/home/lrighi/ora/python/ora/np/__init__.py'>
```

(in both cases, I've built `ora` locally using `python setup.py build_ext --inplace`).